### PR TITLE
Added Redis Caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,13 @@ export TITANIC_QUEST_DATABASE_HOST=localhost
 export TITANIC_QUEST_DATABASE_PORT=5432
 export TITANIC_QUEST_DATABASE_DBNAME=titanic_quest
 
+echo "Set Redis Connection"
+
+export TITANIC_QUEST_REDIS_ENABLE=true
+export TITANIC_QUEST_REDIS_HOST=localhost
+export TITANIC_QUEST_REDIS_PORT=16379
+export TITANIC_QUEST_REDIS_PASS=mypass
+
 echo "Run"
 
 mvn spring-boot:run

--- a/src/main/java/com/iteratia/titanicquest/config/AppConfigurationProperties.java
+++ b/src/main/java/com/iteratia/titanicquest/config/AppConfigurationProperties.java
@@ -1,0 +1,17 @@
+package com.iteratia.titanicquest.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "iteratia.titanicquest")
+@Getter
+@Setter
+public class AppConfigurationProperties {
+    private Integer paginationMax=10;
+    private Integer searchGuessMax=10;
+    private Boolean redisEnable=false;
+    private String loadFileUrl;
+}

--- a/src/main/java/com/iteratia/titanicquest/config/RedisConfiguration.java
+++ b/src/main/java/com/iteratia/titanicquest/config/RedisConfiguration.java
@@ -1,0 +1,27 @@
+package com.iteratia.titanicquest.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+@ConditionalOnProperty(prefix = "iteratia.titanicquest", name = "redis-enable", havingValue = "true")
+public class RedisConfiguration {
+
+    @Bean
+    public RedisCacheConfiguration cacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(60))
+                .disableCachingNullValues()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+    }
+
+}

--- a/src/main/java/com/iteratia/titanicquest/repository/impl/SearchRepositoryDB.java
+++ b/src/main/java/com/iteratia/titanicquest/repository/impl/SearchRepositoryDB.java
@@ -13,6 +13,7 @@ import jakarta.persistence.PersistenceContext;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -28,7 +29,7 @@ public class SearchRepositoryDB implements SearchRepository {
     @PersistenceContext
     private EntityManager entityManager;
 
-    @Value("${search.guess.max}")
+    @Value("${iteratia.titanicquest.search-guess-max}")
     int maxSearchGuess;
 
     // this map contains properties for search by different entities
@@ -111,6 +112,7 @@ public class SearchRepositoryDB implements SearchRepository {
      * @param filters filters for search
      * */
     @Override
+    @Cacheable(cacheNames = "search")
     public <T> List<T> search(String searchRequest, String url, Class<T> entity, Pageable pageable, Filters filters) {
         EntityProperty entityProperty = this.getEntity(url); // get Entity Property
 
@@ -161,6 +163,7 @@ public class SearchRepositoryDB implements SearchRepository {
      * @param filters statistics filters
      * @param statistics statistics for query
      * */
+    @Cacheable(cacheNames = "statistics")
     @Override
     public Number getStatistics(String searchRequest, String url, Filters filters, Statistics statistics) {
         EntityProperty entityProperty = this.getEntity(url); // get Entity Property

--- a/src/main/java/com/iteratia/titanicquest/service/impl/PaginationServiceDB.java
+++ b/src/main/java/com/iteratia/titanicquest/service/impl/PaginationServiceDB.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Service
 public class PaginationServiceDB implements PaginationService {
 
-    @Value("${pagination.max}")
+    @Value("${iteratia.titanicquest.pagination-max}")
     private int maxPages;
 
     /**

--- a/src/main/resources/application-DEV.properties
+++ b/src/main/resources/application-DEV.properties
@@ -9,16 +9,26 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 spring.jpa.hibernate.ddl-auto=validate
 
-spring.jpa.hibernate.show-sql=true
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=false
 
 #Liquibase
 spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 
 #loader source file url
-file.url=https://web.stanford.edu/class/archive/cs/cs109/cs109.1166/stuff/titanic.csv
+iteratia.titanicquest.load-file-url=https://web.stanford.edu/class/archive/cs/cs109/cs109.1166/stuff/titanic.csv
 
 #pages
-pagination.max=4
+iteratia.titanicquest.pagination-max=4
 
 #search
-search.guess.max=8
+iteratia.titanicquest.search-guess-max=8
+
+#redis
+iteratia.titanicquest.redis-enable=true
+
+spring.data.redis.database=0
+spring.data.redis.host=localhost
+spring.data.redis.port=16379
+spring.data.redis.password=mypass
+spring.data.redis.timeout=60000ms

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,8 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 spring.jpa.hibernate.ddl-auto=validate
 
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=false
 
 #Liquibase
 spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
@@ -18,7 +20,16 @@ spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 file.url=https://web.stanford.edu/class/archive/cs/cs109/cs109.1166/stuff/titanic.csv
 
 #pages
-pagination.max=4
+iteratia.titanicquest.pagination-max=4
 
 #search
-search.guess.max=8
+iteratia.titanicquest.search-guess-max=8
+
+#redis
+iteratia.titanicquest.redis-enable=${TITANIC_QUEST_REDIS_ENABLE}
+
+spring.data.redis.database=0
+spring.data.redis.host=${TITANIC_QUEST_REDIS_HOST}
+spring.data.redis.port=${TITANIC_QUEST_REDIS_PORT}
+spring.data.redis.password=${TITANIC_QUEST_REDIS_PASS}
+spring.data.redis.timeout=60000ms


### PR DESCRIPTION
   - Added RedisConfiguration - enable redis cache if property iteratia.titanicquest.redis-enable is true
   - Added dependencies in POM - spring-boot-starter-data-redis and spring-boot-starter-cache

Changed SearchRepositoryDB
   - Added caching for method search and getStatistics

Added AppConfigurationProperties